### PR TITLE
Rc 0.2.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # pyqgc Release Notes
 
-### RELEASE 0.2.1
+### RELEASE 0.2.2
 
 1. Fix LU600 CFG-MSG POLL definition.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
 ]
 
-dependencies = ["pynmeagps >= 1.0.57", "pyrtcm>=1.1.10"]
+dependencies = ["pynmeagps >= 1.1.2", "pyrtcm>=1.1.10"]
 
 [project.urls]
 homepage = "https://github.com/semuconsulting/pyqgc"

--- a/src/pyqgc/_version.py
+++ b/src/pyqgc/_version.py
@@ -8,4 +8,4 @@ Created on 6 Oct 2025
 :license: BSD 3-Clause
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/src/pyqgc/qgcmessage.py
+++ b/src/pyqgc/qgcmessage.py
@@ -94,9 +94,6 @@ class QGCMessage:
         self._suffix = ""  # attribute index suffix ("_01", "_02", etc.)
 
         pdict = self._get_dict(**kwargs)  # get appropriate payload dict
-        print(
-            f"DEBUG {self.identity=} {msgmode=} {length=} {msgid=} {msggrp=} {pdict=}"
-        )
         for anam in pdict:  # process each attribute in dict
             self._set_attribute(anam, pdict, **kwargs)
         self._do_len_checksum()


### PR DESCRIPTION
# pyqgc Pull Request Template

## Description

1. Fix LU600 CFG-MSG POLL definition.
2. Update min pynmeagps version to 1.1.2

Fixes # (issue)

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

If you're adding new QGC message definitions for Generation 9+ devices, please check for any corresponding configuration database updates (`QGCtypes_configdb.py`).

- [x] test_stream.py updated

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pyqgc/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pyqgc/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] (*if appropriate*) I have cited my Quectel documentation source(s).
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
